### PR TITLE
Configurable Delimiter

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: "3.7"
+
+services:
+  directus:
+    image: directus/directus
+    ports:
+     - 8059:8055
+    volumes:
+      - .:/directus/extensions/directus-extension-human-readable-id
+    environment:
+      KEY: asdf
+      SECRET: asdf
+      ADMIN_EMAIL: admin@admin.com
+      ADMIN_PASSWORD: admin
+      PUBLIC_URL: "http://localhost:8055"
+      EXTENSIONS_AUTO_RELOAD: "1"

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export default {
     {
       field: 'delim',
       type: 'string',
-      name: 'Delimeter',
+      name: 'Delimiter',
       meta: {
         width: 'half',
         interface: 'input',

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,21 @@ export default {
   id: 'human-readable-id',
   name: 'Human Readable ID',
   icon: 'badge',
-  description: 'Generate a human-readable text id',
+  description: 'Generate a human-readable text id (e.g. "happy-blue-penguin")',
   component: InterfaceComponent,
-  options: null,
+  options: [
+    {
+      field: 'delim',
+      type: 'string',
+      name: 'Delimeter',
+      meta: {
+        width: 'half',
+        interface: 'input',
+        options: {
+          placeholder: '-',
+        }
+      },
+    },
+  ],
   types: ['string', 'text']
 };

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -113,7 +113,7 @@
           // Check for unexpected delimiter
           if ( parts.length !== 3 ) {
             let delim = this.value.match(/[^a-zA-Z0-9]+/);
-            if (delim) {
+            if (delim && delim[0] !== (this.delim || '-') ) {
               this.otherDelim = delim[0];
               parts = this.value.split(this.otherDelim);
               if ( parts.length > 3 ) {

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -86,7 +86,7 @@
 
     mounted: function() {
       if ( !this.value ) {
-        let init = generate(this.delim);
+        let init = generate(this.delim || '-');
         this.$emit('input', init);
       }
     },
@@ -94,7 +94,7 @@
     methods: {
       formatValue: function() {
         let parts = [this.editAdjective, this.editColor, this.editAnimal].filter(x => x);
-        return parts.join(this.otherDelim || this.delim);
+        return parts.join(this.otherDelim || this.delim || '-');
       },
 
       /**
@@ -103,7 +103,7 @@
       edit: function() {
         let parts = [];
         if ( this.value ) {
-          parts = this.value.split(this.delim);
+          parts = this.value.split(this.delim || '-');
           
           // Check for unexpected delimiter
           if ( parts.length !== 3 ) {
@@ -134,8 +134,8 @@
        * Get a new human-readable-id for the value
        */
       refresh: function() {
-        let value = generate(this.delim);
-        [this.editAdjective, this.editColor, this.editAnimal] = value.split(this.delim);
+        let value = generate(this.delim || '-');
+        [this.editAdjective, this.editColor, this.editAnimal] = value.split(this.delim || '-');
       },
 
       /**

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -48,7 +48,7 @@
       </v-card-text>
       <v-card-actions>
         <v-button @click="editActive = false" outlined>Cancel</v-button>
-        <v-button @click="save" v-if="value !== (formatValue() || value) && !!editColor === !!editAnimal">Save</v-button>
+        <v-button @click="save" v-if="value !== (formatValue() || value)">Update</v-button>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -29,7 +29,7 @@
 
         <VNotice type="warning" v-if="otherDelim">
           <div>
-            <p>Unexpected delimiter: "{{ otherDelim }}" (expected "{{ delim }}")</p>
+            <p>Unexpected delimiter: "{{ otherDelim }}" (expected "{{ delim || '-' }}")</p>
             <v-button @click="otherDelim = null" v-if="otherDelim">Reset delimeter?</v-button>
           </div>
         </VNotice>

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -104,6 +104,11 @@
         let parts = [];
         if ( this.value ) {
           parts = this.value.split(this.delim || '-');
+          if ( parts.length > 3 ) {
+            let [p1, p2, ...rest] = parts;
+            parts = [p1, p2, rest.join(this.delim || '-')];
+          }
+          console.log(parts);
           
           // Check for unexpected delimiter
           if ( parts.length !== 3 ) {
@@ -111,6 +116,10 @@
             if (delim) {
               this.otherDelim = delim[0];
               parts = this.value.split(this.otherDelim);
+              if ( parts.length > 3 ) {
+                let [p1, p2, ...rest] = parts;
+                parts = [p1, p2, rest.join(this.delim || '-')];
+              }
             }
           }
         }


### PR DESCRIPTION
In our project, we are using very similar UIDs, except our IDs were setup with underscores instead of dashes and it would cause issues to try and change them at this point.

This extends the extension to have a more configurable delimiter and to improve resiliency with alternative delimiters.

---

Can set the delimiter in the field config
<img width="631" alt="image" src="https://github.com/user-attachments/assets/e42219ba-e24d-4fc1-ac20-148a036ca8b3">

Added an easy to read value preview (and put the shuffle next to it)
<img width="430" alt="image" src="https://github.com/user-attachments/assets/dec569f4-8f65-4c68-b28f-3ef55e488342">

If the delimiter doesn't match, it will try to detect the first non-alphanumeric separator (specifically `/[^a-zA-Z0-9]+/`).

it gives you the option to fix the delimiter (without forcing the issue in case there are foreign keys)
<img width="437" alt="image" src="https://github.com/user-attachments/assets/b4be6c82-aee9-4681-b310-01ed1b3d3067">

Pressing reset will update the delimiter
<img width="424" alt="image" src="https://github.com/user-attachments/assets/7d7ad148-b351-4bec-853f-3abbd25bff4e">

If it cannot be parsed, it gives you the option to fix it.
<img width="438" alt="image" src="https://github.com/user-attachments/assets/8aec895d-b89e-4217-b677-458a4187d1e6">

Shuffle is now located inside the edit modal so that changes to the value are more intentional
<img width="670" alt="image" src="https://github.com/user-attachments/assets/12c6f33c-a7b1-466b-8919-711e851540e4">

